### PR TITLE
Fix for latest support library (v21-rc1) requiring min/target SDK of android-L

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile 'com.squareup:otto:1.3.+'
     compile 'com.squareup.dagger:dagger:1.+'
     compile 'com.google.guava:guava:17.+'
-    compile 'com.android.support:support-v4:+'
+    compile 'com.android.support:support-v4:19.+'
 
     compile fileTree(dir: 'libs', include: '*.jar')
 }


### PR DESCRIPTION
Avoid the issue by marking the required version for the support-v4 lib as 19.+
